### PR TITLE
Allow users to specify not to push in the headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,10 +335,11 @@ You can also pass both API keys as part of the main LLM `Authorization` header, 
 
 Then, this combined key can be passed as `Authorization` header only.
 
-### Additional Guardrails Headers
+### Additional Headers
 
 - `Invariant-Guardrail-Service-Authorization`: Additional header value to specify a different API key to use for Guardrails evaluation specifically. `Invariant-Authorization` will then only be used to interact with the configured Explorer instance, not for guardrailing.
 - `Invariant-Guardrails`: Guardrailing rules to be checked for a specific request. This list of rules will replace all rules being evaluated, i.e. no additional rules will be pulled from [Explorer](https://explorer.invariantlabs.ai).
+- `Invariant-NoPush`: Disables pushing to Explorer alltogether. Gateway will still pull and evaluate the guardrailing rules stored in Explorer, but it will no longer push the resulting trace.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,31 @@ This will launch Gateway at [http://localhost:8005/api/v1/gateway/](http://local
 
 ---
 
+## Supported Headers
+
+The Invariant Gateway supports several headers for authentication and configuration:
+
+### Authentication Headers
+
+- `Invariant-Authorization`: The primary header for Invariant authentication. Format: `Bearer your-invariant-api-key`
+- `Authorization`: Standard authorization header for LLM provider API keys
+
+### Alternative Authentication Methods
+
+You can also pass authentication by appending the Invariant API key to your LLM provider's API key using the format:
+```
+{your-llm-api-key};invariant-auth={your-invariant-api-key}
+```
+
+Then, this combined key can be passed as `Authorization` header only.
+
+### Additional Guardrails Headers
+
+- `Invariant-Guardrail-Service-Authorization`: Additional header value to specify a different API key to use for Guardrails evaluation specifically.
+- `Invariant-Guardrails`: Guardrailing rules to be checked for a specific request. This list of rules will replace all rules being evaluated, i.e. no additional rules will be pulled from [Explorer](https://explorer.invariantlabs.ai).
+
+---
+
 ## **Development**
 
 ### **Pushing to Local Explorer**

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Then, this combined key can be passed as `Authorization` header only.
 
 - `Invariant-Guardrail-Service-Authorization`: Additional header value to specify a different API key to use for Guardrails evaluation specifically. `Invariant-Authorization` will then only be used to interact with the configured Explorer instance, not for guardrailing.
 - `Invariant-Guardrails`: Guardrailing rules to be checked for a specific request. This list of rules will replace all rules being evaluated, i.e. no additional rules will be pulled from [Explorer](https://explorer.invariantlabs.ai).
-- `Invariant-NoPush`: Disables pushing to Explorer alltogether. Gateway will still pull and evaluate the guardrailing rules stored in Explorer, but it will no longer push the resulting trace.
+- `Invariant-Push`: Configures push behavior of Gateway. Valid values are `push` (default, pushes to Explorer), `skip` (does not push anything)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -324,11 +324,11 @@ The Invariant Gateway supports several headers for authentication and configurat
 ### Authentication Headers
 
 - `Invariant-Authorization`: The primary header for Invariant authentication. Format: `Bearer your-invariant-api-key`
-- `Authorization`: Standard authorization header for LLM provider API keys
+- `Authorization`: Standard authorization header for LLM provider API keys. Passed on as provided.
 
-### Alternative Authentication Methods
+### Alternative Invariant Authentication Methods
 
-You can also pass authentication by appending the Invariant API key to your LLM provider's API key using the format:
+You can also pass both API keys as part of the main LLM `Authorization` header, e.g. if you cannot specify custom headers in your application.
 ```
 {your-llm-api-key};invariant-auth={your-invariant-api-key}
 ```
@@ -337,7 +337,7 @@ Then, this combined key can be passed as `Authorization` header only.
 
 ### Additional Guardrails Headers
 
-- `Invariant-Guardrail-Service-Authorization`: Additional header value to specify a different API key to use for Guardrails evaluation specifically.
+- `Invariant-Guardrail-Service-Authorization`: Additional header value to specify a different API key to use for Guardrails evaluation specifically. `Invariant-Authorization` will then only be used to interact with the configured Explorer instance, not for guardrailing.
 - `Invariant-Guardrails`: Guardrailing rules to be checked for a specific request. This list of rules will replace all rules being evaluated, i.e. no additional rules will be pulled from [Explorer](https://explorer.invariantlabs.ai).
 
 ---

--- a/gateway/integrations/explorer.py
+++ b/gateway/integrations/explorer.py
@@ -74,6 +74,7 @@ async def push_trace(
     invariant_authorization: str,
     annotations: List[List[AnnotationCreate]] = None,
     metadata: List[Dict[str, Any]] = None,
+    push_behavior: str = "push",
 ) -> PushTracesResponse:
     """Pushes traces to the dataset on the Invariant Explorer.
 
@@ -88,6 +89,12 @@ async def push_trace(
     Returns:
         PushTracesResponse: Response containing the trace ID details.
     """
+    # if push_behavior is skip, do not push anything
+    if push_behavior == "skip":
+        return None
+
+    # otherwise, we assume we need to push
+
     # Remove any None values from the messages
     update_messages = [
         [{k: v for k, v in msg.items() if v is not None} for msg in msg_list]

--- a/gateway/routes/anthropic.py
+++ b/gateway/routes/anthropic.py
@@ -196,6 +196,7 @@ async def push_to_explorer(
         invariant_authorization=context.invariant_authorization,
         metadata=[create_metadata(context, merged_response)],
         annotations=[annotations] if annotations else None,
+        push_behavior=context.push_behavior,
     )
 
 

--- a/gateway/routes/gemini.py
+++ b/gateway/routes/gemini.py
@@ -437,6 +437,7 @@ async def push_to_explorer(
         invariant_authorization=context.invariant_authorization,
         metadata=[create_metadata(context, response_json)],
         annotations=[annotations] if annotations else None,
+        push_behavior=context.push_behavior,
     )
 
 

--- a/gateway/routes/open_ai.py
+++ b/gateway/routes/open_ai.py
@@ -520,6 +520,7 @@ async def push_to_explorer(
             messages=[messages],
             annotations=[annotations],
             metadata=[create_metadata(context, merged_response)],
+            push_behavior=context.push_behavior,
         )
 
 

--- a/tests/integration/guardrails/test_push_behavior.py
+++ b/tests/integration/guardrails/test_push_behavior.py
@@ -1,0 +1,134 @@
+"""Test the Invariant-Push header behaviors with the OpenAI route."""
+
+import os
+import sys
+import uuid
+import time
+
+# Add integration folder (parent) to sys.path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+import requests
+from httpx import Client
+from openai import OpenAI
+
+# Pytest plugins
+pytest_plugins = ("pytest_asyncio",)
+
+
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="No OPENAI_API_KEY set")
+@pytest.mark.parametrize(
+    "do_stream, push_behavior",
+    [(True, "push"), (True, "skip"), (False, "push"), (False, "skip")],
+)
+async def test_push_behavior(explorer_api_url, gateway_url, do_stream, push_behavior):
+    """Test the Invariant-Push header behaviors."""
+    if not os.getenv("INVARIANT_API_KEY"):
+        pytest.fail("No INVARIANT_API_KEY set, failing")
+
+    dataset_name = f"test-dataset-push-behavior-{uuid.uuid4()}"
+
+    client = OpenAI(
+        http_client=Client(
+            headers={
+                "Invariant-Authorization": f"Bearer {os.getenv('INVARIANT_API_KEY')}",
+                "Invariant-Push": push_behavior,
+            },
+        ),
+        base_url=f"{gateway_url}/api/v1/gateway/{dataset_name}/openai",
+    )
+
+    request = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "Say hello!"}],
+    }
+
+    # Make the request
+    chat_response = client.chat.completions.create(
+        **request,
+        stream=do_stream,
+    )
+
+    # If streaming, consume the stream
+    if do_stream:
+        response_content = ""
+        for chunk in chat_response:
+            if chunk.choices[0].delta.content:
+                response_content += chunk.choices[0].delta.content
+    else:
+        response_content = chat_response.choices[0].message.content
+
+    assert response_content, "Response should not be empty"
+
+    # Wait for potential trace saving
+    time.sleep(2)
+
+    # Check if trace was saved based on push_behavior
+    traces_response = requests.get(
+        f"{explorer_api_url}/api/v1/dataset/byuser/developer/{dataset_name}/traces",
+        timeout=5,
+    )
+    traces = traces_response.json()
+
+    if push_behavior == "push":
+        assert len(traces) == 1, "Trace should be saved when push_behavior is 'push'"
+        
+        # Verify trace contents
+        trace_id = traces[0]["id"]
+        trace_response = requests.get(
+            f"{explorer_api_url}/api/v1/trace/{trace_id}",
+            timeout=5,
+        )
+        trace = trace_response.json()
+        
+        assert len(trace["messages"]) == 2, "Trace should contain both request and response"
+        assert trace["messages"][0]["role"] == "user"
+        assert trace["messages"][0]["content"] == "Say hello!"
+        assert trace["messages"][1]["role"] == "assistant"
+        assert trace["messages"][1]["content"] in response_content
+    else:  # push_behavior == "skip"
+        assert len(traces) == 0, "No trace should be saved when push_behavior is 'skip'"
+
+
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="No OPENAI_API_KEY set")
+async def test_invalid_push_behavior(explorer_api_url, gateway_url):
+    """Test invalid Invariant-Push header value."""
+    if not os.getenv("INVARIANT_API_KEY"):
+        pytest.fail("No INVARIANT_API_KEY set, failing")
+
+    dataset_name = f"test-dataset-push-behavior-{uuid.uuid4()}"
+
+    client = OpenAI(
+        http_client=Client(
+            headers={
+                "Invariant-Authorization": f"Bearer {os.getenv('INVARIANT_API_KEY')}",
+                "Invariant-Push": "invalid_value",  # Invalid push behavior
+            },
+        ),
+        base_url=f"{gateway_url}/api/v1/gateway/{dataset_name}/openai",
+    )
+
+    request = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "Say hello!"}],
+    }
+
+    # The request should still work, defaulting to "push" behavior
+    chat_response = client.chat.completions.create(
+        **request,
+        stream=False,
+    )
+
+    assert chat_response.choices[0].message.content, "Response should not be empty"
+
+    # Wait for trace saving
+    time.sleep(2)
+
+    # Check if trace was saved (should default to push behavior)
+    traces_response = requests.get(
+        f"{explorer_api_url}/api/v1/dataset/byuser/developer/{dataset_name}/traces",
+        timeout=5,
+    )
+    traces = traces_response.json()
+    assert len(traces) == 1, "Trace should be saved when push_behavior is invalid (defaults to push)" 


### PR DESCRIPTION
This PR adds the option to send request through Gateway just for guardrailing, but to not push the traces.

This can be configured via a new `Invariant-Push` header, as described in the updated README.