### PR TITLE
Use tenacity.RetryError instead of genai.errors.ClientError for gemini guardrailing errors in integration tests.

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -9,4 +9,5 @@ pytest
 pytest-asyncio
 pytest-timeout
 tavily-python
+tenacity
 uv


### PR DESCRIPTION
The ClientError is being wrapped in tenacity.RetryError. This is a new change and we don't freeze the gemini gen-ai python library dependency version for our integrations tests.